### PR TITLE
Added extended templates

### DIFF
--- a/backbone.collection.extended.sublime-snippet
+++ b/backbone.collection.extended.sublime-snippet
@@ -1,0 +1,13 @@
+<snippet>
+    <content><![CDATA[
+Backbone.Collection.extend({
+	model: ${0:model},
+	initialize: function(options) {
+
+	}
+});
+]]></content>
+    <tabTrigger>bce</tabTrigger>
+    <scope>source.js</scope>
+    <description>Backbone Collection Extended</description>
+</snippet>

--- a/backbone.model.extended.sublime-snippet
+++ b/backbone.model.extended.sublime-snippet
@@ -1,0 +1,19 @@
+<snippet>
+	<content><![CDATA[Backbone.Model.extend({
+	defaults: function() {
+		return {
+			${0}
+		};
+	},
+	initialize: function(options) {
+
+	}
+});]]>
+	</content>
+	<!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
+	<tabTrigger>bme</tabTrigger>
+	<!-- Optional: Set a scope to limit where the snippet will trigger -->
+	<scope>source.js</scope>
+    <!-- Optional: Description to show in the menu -->
+    <description>Backbone Model Extended</description>
+</snippet>

--- a/backbone.router.extended.sublime-snippet
+++ b/backbone.router.extended.sublime-snippet
@@ -1,0 +1,17 @@
+<snippet>
+    <content><![CDATA[
+Backbone.Router.extend({
+	routes: {
+		"*action":"defaultAction",
+	},
+	initialize: function(options) {
+		${0}
+	},
+	defaultAction: function(action) {
+
+	}
+});]]></content>
+    <tabTrigger>bre</tabTrigger>
+    <scope>source.js</scope>
+    <description>Backbone Router Extended</description>
+</snippet>

--- a/backbone.view.extended.sublime-snippet
+++ b/backbone.view.extended.sublime-snippet
@@ -1,0 +1,20 @@
+<snippet>
+	<content><![CDATA[Backbone.View.extend({
+	events: {
+
+	},
+	initialize: function(options) {
+		${0}
+	},
+	render: function() {
+
+	}
+});]]>
+	</content>
+	<!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
+	<tabTrigger>bve</tabTrigger>
+	<!-- Optional: Set a scope to limit where the snippet will trigger -->
+	<scope>source.js</scope>
+    <!-- Optional: Description to show in the menu -->
+    <description>Backbone View Extended</description>
+</snippet>


### PR DESCRIPTION
I added four new snippets, labelled backbone.[type].extended, that add the indicated type of object (model, view, etc.) with some basic attributes, such as `initialize` or `render`, already fluffed up.

What do you think?
